### PR TITLE
fix uppercase character class (strlib pattern)

### DIFF
--- a/Assets/UniLua/LuaStrLib.cs
+++ b/Assets/UniLua/LuaStrLib.cs
@@ -199,7 +199,7 @@ namespace UniLua
 		private static bool MatchClass( char c, char cl )
 		{
 			bool res;
-			switch(cl)
+			switch(Char.ToLower (cl))
 			{
 				case 'a': res = Char.IsLetter(c); break;
 				case 'c': res = Char.IsControl(c); break;
@@ -214,7 +214,7 @@ namespace UniLua
 				case 'z': res = (c == '\0'); break;  /* deprecated option */
 				default: return (cl == c);
 			}
-			return res;
+			return (Char.IsLower (cl) ? res : !res);
 		}
 
 		private static bool MatchBreaketClass( MatchState ms, char c, int p, int ec )


### PR DESCRIPTION
check lua manual 6.4.1:
"For all classes represented by single letters (%a, %c, etc.), the corresponding uppercase letter represents the complement of the class. For instance, %S represents all non-space characters."